### PR TITLE
Remove references to unused vim plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,7 @@ Vim plugins can be installed with:
 mkdir -p ~/.vim/pack/plugins/opt
 cd ~/.vim/pack/plugins/opt
 git clone git@github.com:tpope/vim-sensible.git
-git clone git@github.com:kien/ctrlp.vim.git
 git clone git@github.com:christoomey/vim-tmux-navigator.git
-git clone git@github.com:christoomey/vim-tmux-runner.git
-git clone git@github.com:tpope/vim-rails.git
-git clone git@github.com:dense-analysis/ale.git
-git clone git@github.com:tpope/vim-surround.git
 git clone git@github.com:junegunn/fzf.git
 git clone git@github.com:junegunn/fzf.vim.git
 ```
@@ -79,7 +74,6 @@ The vim configuration includes:
 - No backup/swap files
 - Custom key mappings
 - Integration with tmux
-- ALE linter configuration for Ruby (using standard)
 - FZF integration for fuzzy file finding (requires FZF executable to be installed via `brew install fzf` on macOS)
 
 ### Git Configuration (gitconfig and gitignore_global)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,7 @@ ln -sf ~/code/personal/dotfiles/gitconfig ~/.gitconfig
 mkdir -p ~/.vim/pack/plugins/opt
 cd ~/.vim/pack/plugins/opt
 git clone git@github.com:tpope/vim-sensible.git
-git clone git@github.com:kien/ctrlp.vim.git
 git clone git@github.com:christoomey/vim-tmux-navigator.git
-git clone git@github.com:christoomey/vim-tmux-runner.git
-git clone git@github.com:tpope/vim-rails.git
-git clone git@github.com:dense-analysis/ale.git
-git clone git@github.com:tpope/vim-surround.git
 git clone git@github.com:junegunn/fzf.git
 git clone git@github.com:junegunn/fzf.vim.git
 ```
@@ -68,7 +63,7 @@ The configuration includes fuzzy finding with FZF for efficient file navigation.
 
 #### Key Bindings
 
-- `Ctrl+p`: Open file finder (similar to CtrlP plugin)
+- `Ctrl+p`: Open file finder
 - `<leader>b`: Browse open buffers
 - `<leader>g`: Search git files (respects .gitignore)
 - `<leader>r`: Search file contents using ripgrep


### PR DESCRIPTION
- Remove CtrlP, ALE, vim-tmux-runner, vim-rails, and vim-surround
- Update documentation to reflect only the plugins that are actually used
- Simplify installation instructions in both README and CLAUDE.md
- Remove mention of ALE linter from vim configuration description

🤖 Generated with [Claude Code](https://claude.ai/code)